### PR TITLE
[16.0][FIX] stock_picking_portal: implement portal_visible flag

### DIFF
--- a/stock_picking_portal/__manifest__.py
+++ b/stock_picking_portal/__manifest__.py
@@ -11,6 +11,7 @@
     "website": "https://github.com/OCA/stock-logistics-workflow",
     "data": [
         "security/ir.model.access.csv",
+        "security/stock_picking_portal_rule.xml",
         "views/res_config_settings_view.xml",
         "views/stock_picking_template.xml",
         "wizards/picking_link_wizard.xml",

--- a/stock_picking_portal/models/__init__.py
+++ b/stock_picking_portal/models/__init__.py
@@ -1,2 +1,3 @@
 from . import res_config_settings
 from . import stock_picking
+from . import stock_picking_type

--- a/stock_picking_portal/models/res_config_settings.py
+++ b/stock_picking_portal/models/res_config_settings.py
@@ -13,25 +13,37 @@ class ResConfigSettings(models.TransientModel):
     )
 
     def set_values(self):
-        super().set_values()
-        ICPSudo = self.env["ir.config_parameter"].sudo()
-        ICPSudo.set_param(
-            "stock_picking_portal.portal_visible_operation_ids",
-            ",".join(str(i) for i in self.portal_visible_operation_ids.ids),
+        """Save the M2M into the boolean field on stock.picking.type,
+        updating only the records whose flag have changed."""
+        res = super().set_values()
+        selected = self.portal_visible_operation_ids
+        currently_visible = self.env["stock.picking.type"].search(
+            [
+                ("portal_visible", "=", True),
+            ],
         )
-        return
+
+        to_invisible = currently_visible - selected
+        to_visible = selected - currently_visible
+
+        if to_invisible:
+            to_invisible.write({"portal_visible": False})
+        if to_visible:
+            to_visible.write({"portal_visible": True})
+
+        return res
 
     @api.model
     def get_values(self):
         res = super().get_values()
-        ICPSudo = self.env["ir.config_parameter"].sudo()
-        portal_visible_operation_ids = ICPSudo.get_param(
-            "stock_picking_portal.portal_visible_operation_ids", default=False
-        )
-        if portal_visible_operation_ids:
-            res.update(
-                portal_visible_operation_ids=[
-                    int(r) for r in portal_visible_operation_ids.split(",")
-                ]
+        visible_ids = (
+            self.env["stock.picking.type"]
+            .search(
+                [
+                    ("portal_visible", "=", True),
+                ],
             )
+            .ids
+        )
+        res.update(portal_visible_operation_ids=visible_ids)
         return res

--- a/stock_picking_portal/models/stock_picking.py
+++ b/stock_picking_portal/models/stock_picking.py
@@ -13,8 +13,9 @@ class StockPick(models.Model):
 
     @api.model
     def _get_available_operations(self):
-        values = self.env["res.config.settings"].sudo().get_values()
-        return values.get("portal_visible_operation_ids", [])
+        return (
+            self.env["stock.picking.type"].search([("portal_visible", "=", True)]).ids
+        )
 
     def _compute_access_url(self):
         super()._compute_access_url()

--- a/stock_picking_portal/models/stock_picking_type.py
+++ b/stock_picking_portal/models/stock_picking_type.py
@@ -1,0 +1,14 @@
+# Copyright (C) 2024 Cetmix OÜ
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class StockPickingType(models.Model):
+    _inherit = "stock.picking.type"
+
+    portal_visible = fields.Boolean(
+        string="Visible in Portal",
+        default=False,
+        help="If checked, pickings of this type will be shown in the customer portal.",
+    )

--- a/stock_picking_portal/security/stock_picking_portal_rule.xml
+++ b/stock_picking_portal/security/stock_picking_portal_rule.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+  <!-- Portal users may read only pickings of visible types and their own partner -->
+  <record id="rule_portal_picking" model="ir.rule">
+    <field name="name">Stock Picking Portal Access</field>
+    <field name="model_id" ref="stock.model_stock_picking" />
+    <field name="domain_force">
+      ['&amp;',
+       ('picking_type_id.portal_visible', '=', True),
+       ('partner_id', '=', user.partner_id.id)]
+    </field>
+    <field name="groups" eval="[(4, ref('base.group_portal'))]" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_write" eval="0" />
+    <field name="perm_create" eval="0" />
+    <field name="perm_unlink" eval="0" />
+  </record>
+
+  <!-- Portal users may read only picking types marked portal_visible -->
+  <record id="rule_portal_picking_type" model="ir.rule">
+    <field name="name">Stock Picking Type Portal Access</field>
+    <field name="model_id" ref="stock.model_stock_picking_type" />
+    <field name="domain_force">[('portal_visible','=',True)]</field>
+    <field name="groups" eval="[(4, ref('base.group_portal'))]" />
+    <field name="perm_read" eval="1" />
+    <field name="perm_write" eval="0" />
+    <field name="perm_create" eval="0" />
+    <field name="perm_unlink" eval="0" />
+  </record>
+</odoo>

--- a/stock_picking_portal/static/description/index.html
+++ b/stock_picking_portal/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -462,7 +463,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/stock_picking_portal/views/res_config_settings_view.xml
+++ b/stock_picking_portal/views/res_config_settings_view.xml
@@ -1,27 +1,28 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-    <record id="res_config_settings_view_form" model="ir.ui.view">
-        <field name="name">res.config.settings.view.form.inherit.stock</field>
-        <field name="model">res.config.settings</field>
-        <field name="priority" eval="99" />
-        <field name="inherit_id" ref="stock.res_config_settings_view_form" />
-        <field name="arch" type="xml">
-            <xpath expr="//div[@name='operations_setting_container']" position="inside">
-                <div class="col-12 col-lg-6 o_setting_box" id="stock_picking_portal">
-                    <div class="o_setting_left_pane" />
-                    <div class="o_setting_right_pane">
-                        <div class="row mt16">
-                            <label for="portal_visible_operation_ids" />
-                            <field
+  <record id="res_config_settings_view_inherit" model="ir.ui.view">
+    <field name="name">res.config.settings.stock_picking_portal</field>
+    <field name="model">res.config.settings</field>
+    <field name="inherit_id" ref="stock.res_config_settings_view_form" />
+    <field name="arch" type="xml">
+      <xpath expr="//div[@name='operations_setting_container']" position="inside">
+        <div class="col-12 col-lg-6 o_setting_box" id="stock_picking_portal">
+          <div class="o_setting_left_pane" />
+          <div class="o_setting_right_pane">
+            <div class="row mt16">
+              <label for="portal_visible_operation_ids" />
+              <field
                                 name="portal_visible_operation_ids"
                                 widget="many2many_tags"
+                                placeholder="Select operation types..."
                             />
-                        </div>
-                        <div class="text-muted">
-                            </div>
-                    </div>
-                </div>
-            </xpath>
-        </field>
-    </record>
+            </div>
+            <div class="text-muted">
+              Select which stock operation types should be visible to portal users.
+            </div>
+          </div>
+        </div>
+      </xpath>
+    </field>
+  </record>
 </odoo>


### PR DESCRIPTION
- Introduce a boolean portal_visible on stock.picking.type to drive portal visibility. 

- Simplify res.config.settings to read/write this flag. 

Task: 3612

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a boolean visibility toggle on stock operation types to control portal access.
  - Implemented access rules restricting portal users to view only stock pickings of visible types linked to their account.

- **Improvements**
  - Refined configuration settings to directly manage visibility on operation types instead of using system parameters.
  - Updated configuration interface with clearer descriptions, placeholders, and improved selection options.
  - Enhanced view formatting for better readability and usability.

- **Style**
  - Minor updates to documentation styling and code block appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->