### PR TITLE
[18.0][IMP] stock_picking_auto_create_lot: support custom lot/serial sequences

### DIFF
--- a/stock_picking_auto_create_lot/README.rst
+++ b/stock_picking_auto_create_lot/README.rst
@@ -39,23 +39,49 @@ create lots for incoming pickings.
 Configuration
 =============
 
-To configure this module, you need to:
+To use the auto-create feature you need to enable tracking by
+lots/serial numbers:
 
-1. Go to a *Inventory > Configuration > Operation Types*.
-2. Set 'auto create lot' option for this operation type.
-3. Go to a *Inventory > Master Data > Products*.
-4. Set 'auto create lot' option for the products you need.
+1. Go to "Inventory > Configuration > Settings" and scroll down to the
+   "Traceability" section;
+2. Enable the "Lots & Serial Numbers" setting;
+3. You can select the number of trailing zeroes for the SKU-based
+   lots/serial numbers in the "SKU Based Numbers Trailing" field located
+   in the same section. Default value is "0".
+
+Configure the operation types:
+
+1. Go to "Inventory > Configuration > Operation Types";
+2. Enable the "Auto Create Lot" setting located in the "Lots/Serial
+   numbers" section.
+
+Configure the products you want to enable lot/serial number
+auto-creation:
+
+1. Open the product form;
+2. Activate the "Track Inventory" setting and select either "By Unique
+   Serial Number" or "By Lots" option;
+3. Select an option you would like to use for creating lots/serial
+   numbers for this product in the "Auto Create Lot" field. Default
+   options are:
+
+   1. Odoo sequence. Will use default Odoo sequence for newly created
+      lots;
+   2. SKU based. Will use product reference as a base of the sequence
+      and a number as a suffix joined by the "-" symbol. Eg for product
+      with SKU "CHAIR-L-R" serial numbers will be "CHAIR-L-R-1",
+      "CHAIR-L-R-2" etc. Note: if a product doesn't have an SKU default
+      Odoo sequence will be used.
 
 Usage
 =====
 
 To use this module you need to:
 
-1. Go to a *Product > General Information tab*.
-2. Set a tracking option for this product.
-3. Set auto create lot.
-4. Go to *Inventory > Incoming* and create one.
-5. Validate picking without lot.
+1. Create an incoming inventory operation
+2. Do not add lots or serial numbers manually
+3. Validate the operation
+4. Lots/serial numbers will be created automatically
 
 Bug Tracker
 ===========
@@ -87,6 +113,11 @@ Contributors
 - `Quartile <https://www.quartile.co>`__:
 
   - Aung Ko Ko Lin
+
+- `Cetmix <https://cetmix.com/>`__
+
+  - Ivan Sokolov
+  - Dmitry Meita
 
 Maintainers
 -----------

--- a/stock_picking_auto_create_lot/__manifest__.py
+++ b/stock_picking_auto_create_lot/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Stock Picking Auto Create Lot",
     "summary": "Auto create lots for incoming pickings",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "development_status": "Production/Stable",
     "category": "stock",
     "website": "https://github.com/OCA/stock-logistics-workflow",
@@ -12,6 +12,10 @@
     "license": "AGPL-3",
     "installable": True,
     "depends": ["stock"],
-    "data": ["views/product_views.xml", "views/stock_picking_type_views.xml"],
+    "data": [
+        "views/product_views.xml",
+        "views/stock_picking_type_views.xml",
+        "views/res_config_settings_views.xml",
+    ],
     "maintainers": ["sergio-teruel"],
 }

--- a/stock_picking_auto_create_lot/migrations/18.0.1.0.1/post-migrate.py
+++ b/stock_picking_auto_create_lot/migrations/18.0.1.0.1/post-migrate.py
@@ -1,0 +1,11 @@
+# Copyright 2018 Tecnativa - Sergio Teruel
+# Copyright 2026 Cetmix OÜ
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+
+def migrate(cr, version):
+    cr.execute("""
+        UPDATE product_template
+        SET auto_create_lot_option = 'odoo_sequence'
+        WHERE auto_create_lot IS TRUE
+    """)

--- a/stock_picking_auto_create_lot/models/__init__.py
+++ b/stock_picking_auto_create_lot/models/__init__.py
@@ -1,6 +1,8 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from . import product
+from . import product_template
+from . import product_product
 from . import stock_picking
 from . import stock_picking_type
 from . import stock_move
 from . import stock_move_line
+from . import res_config_settings

--- a/stock_picking_auto_create_lot/models/product.py
+++ b/stock_picking_auto_create_lot/models/product.py
@@ -1,9 +1,0 @@
-# Copyright 2018 Tecnativa - Sergio Teruel
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo import fields, models
-
-
-class ProductTemplate(models.Model):
-    _inherit = "product.template"
-
-    auto_create_lot = fields.Boolean()

--- a/stock_picking_auto_create_lot/models/product_product.py
+++ b/stock_picking_auto_create_lot/models/product_product.py
@@ -1,0 +1,128 @@
+from odoo import api, fields, models
+
+from .res_config_settings import CONFIG_PARAM_SKU_TRAILING
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    auto_create_lot_sequence_id = fields.Many2one(
+        comodel_name="ir.sequence",
+        string="Auto Lot/Serial Sequence",
+        copy=False,
+        help="Dedicated per-product sequence used for SKU-based lot/serial generation.",
+    )
+
+    @api.model
+    def _auto_lot_get_trailing(self) -> int:
+        """Return SKU-based numbers trailing (padding) from system settings.
+
+        :return: Padding width (leading zeroes) for SKU-based numbers.
+        :rtype: int
+        """
+        ir_config_value = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param(CONFIG_PARAM_SKU_TRAILING, default="0")
+        )
+        try:
+            trailing = int(ir_config_value)
+        except (TypeError, ValueError):
+            trailing = 0
+        return max(trailing, 0)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        products = super().create(vals_list)
+        products._auto_lot_sequence_sync_if_needed()
+        return products
+
+    def write(self, vals):
+        res = super().write(vals)
+        # SKU change affects prefix; company change affects sequence company
+        if {"default_code", "company_id"} & set(vals):
+            self._auto_lot_sequence_sync_if_needed()
+        return res
+
+    def unlink(self):
+        """Delete related per-product sequences together with products.
+
+        :return: Unlink result from super.
+        :rtype: bool
+        """
+        sequences = self.auto_create_lot_sequence_id
+        res = super().unlink()
+        if sequences:
+            sequences.sudo().unlink()
+        return res
+
+    def _auto_lot_sequence_sync_if_needed(self, trailing: int | None = None):
+        """Create/update per-product sequence for SKU-based generation.
+
+        Sequence is created only for products with:
+          - auto_create_lot_option == 'sku_based' on template
+          - non-empty SKU (default_code)
+
+        Sequence properties:
+          - prefix: '<SKU>-'
+          - padding: trailing from settings
+          - company_id: product company (or False)
+
+        :param int trailing: Optional padding override.
+          If not provided, taken from settings.
+        """
+        products = self.filtered(
+            lambda p: p.product_tmpl_id.auto_create_lot_option == "sku_based"
+            and p.default_code
+        )
+        if not products:
+            return
+
+        trailing = (
+            self._auto_lot_get_trailing() if trailing is None else max(int(trailing), 0)
+        )
+
+        IrSequence = self.env["ir.sequence"].sudo()
+
+        seq_vals_list: list[dict] = []
+        create_products: list = []
+        seq_updates: list[tuple] = []
+
+        for product in products:
+            prefix = f"{product.default_code}-"
+            company_id = product.company_id.id or False
+            seq = product.auto_create_lot_sequence_id
+
+            if not seq:
+                create_products.append(product)
+                seq_vals_list.append(
+                    {
+                        "name": f"Lot/Serial for {product.default_code}",
+                        "implementation": "standard",
+                        "prefix": prefix,
+                        "padding": trailing,
+                        "number_next_actual": 1,
+                        "number_increment": 1,
+                        "company_id": company_id,
+                    }
+                )
+                continue
+
+            vals = {}
+            if seq.prefix != prefix:
+                vals["prefix"] = prefix
+            if seq.padding != trailing:
+                vals["padding"] = trailing
+            if (seq.company_id.id or False) != company_id:
+                vals["company_id"] = company_id
+
+            if vals:
+                seq_updates.append((seq, vals))
+
+        if seq_vals_list:
+            created = IrSequence.create(seq_vals_list)
+            for product, seq in zip(create_products, created, strict=False):
+                product.auto_create_lot_sequence_id = seq.id
+
+        for seq, vals in seq_updates:
+            seq.write(vals)

--- a/stock_picking_auto_create_lot/models/product_template.py
+++ b/stock_picking_auto_create_lot/models/product_template.py
@@ -1,0 +1,29 @@
+# Copyright 2018 Tecnativa - Sergio Teruel
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    def _selection_auto_create_lot_option(self):
+        """Return possible auto lot/serial generation options.
+
+        :return: List of (value, label) pairs for selection field.
+        :rtype: list[tuple[str, str]]
+        """
+        return [
+            ("odoo_sequence", self.env._("Odoo sequence")),
+            ("sku_based", self.env._("SKU based")),
+        ]
+
+    auto_create_lot_option = fields.Selection(
+        selection="_selection_auto_create_lot_option",
+        help="Controls how lots/serial numbers are auto-generated for this product.",
+    )
+
+    def write(self, vals):
+        res = super().write(vals)
+        if "auto_create_lot_option" in vals:
+            self.mapped("product_variant_ids")._auto_lot_sequence_sync_if_needed()
+        return res

--- a/stock_picking_auto_create_lot/models/res_config_settings.py
+++ b/stock_picking_auto_create_lot/models/res_config_settings.py
@@ -1,0 +1,26 @@
+# Copyright 2018 Tecnativa - Sergio Teruel
+# Copyright 2026 Cetmix OÜ
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
+
+CONFIG_PARAM_SKU_TRAILING = "stock_picking_auto_create_lot.sku_based_numbers_trailing"
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    sku_based_numbers_trailing = fields.Integer(
+        default=0,
+        config_parameter=CONFIG_PARAM_SKU_TRAILING,
+        help="Number of leading zeroes for SKU-based lot/serial suffix (e.g. 3 -> 001)",
+    )
+
+    @api.constrains("sku_based_numbers_trailing")
+    def _check_sku_based_numbers_trailing(self):
+        for rec in self:
+            if rec.sku_based_numbers_trailing < 0:
+                raise ValidationError(
+                    self.env._("SKU Based Numbers Trailing must be 0 or greater.")
+                )

--- a/stock_picking_auto_create_lot/models/stock_move.py
+++ b/stock_picking_auto_create_lot/models/stock_move.py
@@ -9,14 +9,15 @@ class StockMove(models.Model):
     @api.depends(
         "has_tracking",
         "picking_type_id.auto_create_lot",
-        "product_id.auto_create_lot",
+        "product_id.auto_create_lot_option",
         "picking_type_id.use_existing_lots",
         "state",
     )
     def _compute_display_assign_serial(self):
         super()._compute_display_assign_serial()
         moves_not_display = self.filtered(
-            lambda m: m.picking_type_id.auto_create_lot and m.product_id.auto_create_lot
+            lambda m: m.picking_type_id.auto_create_lot
+            and m.product_id.auto_create_lot_option
         )
         for move in moves_not_display:
             move.display_assign_serial = False
@@ -30,7 +31,7 @@ class StockMove(models.Model):
                 continue
             if (
                 move.product_id.tracking == "none"
-                or not move.product_id.auto_create_lot
+                or not move.product_id.auto_create_lot_option
                 or not move.picking_type_id.auto_create_lot
             ):
                 continue

--- a/stock_picking_auto_create_lot/models/stock_move_line.py
+++ b/stock_picking_auto_create_lot/models/stock_move_line.py
@@ -7,6 +7,32 @@ from odoo import models
 class StockMoveLine(models.Model):
     _inherit = "stock.move.line"
 
-    def _get_lot_sequence(self):
+    def _get_lot_sequence(self) -> str:
+        """Return the next lot/serial name for this move line.
+
+        For SKU-based products:
+          - uses a dedicated per-product ir.sequence
+            (prefix '<SKU>-', padding from settings).
+        Fallback:
+          - uses default Odoo sequence 'stock.lot.serial'
+            when SKU-based is not applicable or per-product
+            sequence is not available.
+
+        :return: Generated lot/serial name.
+        :rtype: str
+        """
         self.ensure_one()
-        return self.env["ir.sequence"].next_by_code("stock.lot.serial")
+        product = self.product_id
+
+        if (
+            product.product_tmpl_id.auto_create_lot_option != "sku_based"
+            or not product.default_code
+        ):
+            return self.env["ir.sequence"].next_by_code("stock.lot.serial")
+
+        seq = product.auto_create_lot_sequence_id
+        if not seq:
+            # Sequence should be prepared by product create/write or by picking flow.
+            return self.env["ir.sequence"].next_by_code("stock.lot.serial")
+
+        return seq.sudo().with_company(self.company_id).next_by_id()

--- a/stock_picking_auto_create_lot/models/stock_picking.py
+++ b/stock_picking_auto_create_lot/models/stock_picking.py
@@ -3,23 +3,42 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from odoo import models
 
+from .res_config_settings import CONFIG_PARAM_SKU_TRAILING
+
 
 class StockPicking(models.Model):
     _inherit = "stock.picking"
 
     def _set_auto_lot(self):
-        """
-        Allows to be called either by button or through code
-        """
+        """Assign lot_name automatically for eligible move lines."""
         pickings = self.filtered(lambda p: p.picking_type_id.auto_create_lot)
+        if not pickings:
+            return
+
         lines = pickings.mapped("move_line_ids").filtered(
             lambda x: (
                 not x.lot_id
                 and not x.lot_name
                 and x.product_id.tracking != "none"
-                and x.product_id.auto_create_lot
+                and bool(x.product_id.product_tmpl_id.auto_create_lot_option)
             )
         )
+        if not lines:
+            return
+
+        trailing = int(
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param(CONFIG_PARAM_SKU_TRAILING, "0")
+        )
+
+        sku_products = lines.mapped("product_id").filtered(
+            lambda p: p.product_tmpl_id.auto_create_lot_option == "sku_based"
+            and bool(p.default_code)
+        )
+        if sku_products:
+            sku_products._auto_lot_sequence_sync_if_needed(trailing=trailing)
+
         for line in lines:
             line.lot_name = line._get_lot_sequence()
 

--- a/stock_picking_auto_create_lot/readme/CONFIGURE.md
+++ b/stock_picking_auto_create_lot/readme/CONFIGURE.md
@@ -1,6 +1,18 @@
-To configure this module, you need to:
+To use the auto-create feature you need to enable tracking by lots/serial numbers:
 
-1.  Go to a *Inventory \> Configuration \> Operation Types*.
-2.  Set 'auto create lot' option for this operation type.
-3.  Go to a *Inventory \> Master Data \> Products*.
-4.  Set 'auto create lot' option for the products you need.
+1.  Go to "Inventory > Configuration > Settings" and scroll down to the "Traceability" section;
+2.  Enable the "Lots & Serial Numbers" setting;
+3.  You can select the number of trailing zeroes for the SKU-based lots/serial numbers in the "SKU Based Numbers Trailing" field located in the same section. Default value is "0".
+
+Configure the operation types:
+
+1.  Go to  "Inventory > Configuration > Operation Types";
+2.  Enable the "Auto Create Lot" setting located in the "Lots/Serial numbers" section.
+
+Configure the products you want to enable lot/serial number auto-creation:
+
+1.  Open the product form;
+2.  Activate the "Track Inventory" setting and select either "By Unique Serial Number" or "By Lots" option;
+3.  Select an option you would like to use for creating lots/serial numbers for this product in the "Auto Create Lot" field. Default options are:
+    1.  Odoo sequence. Will use default Odoo sequence for newly created lots;
+    2.  SKU based. Will use product reference as a base of the sequence and a number as a suffix joined by the "-" symbol. Eg for product with SKU "CHAIR-L-R" serial numbers will be "CHAIR-L-R-1", "CHAIR-L-R-2" etc. Note: if a product doesn't have an SKU default Odoo sequence will be used.

--- a/stock_picking_auto_create_lot/readme/CONTRIBUTORS.md
+++ b/stock_picking_auto_create_lot/readme/CONTRIBUTORS.md
@@ -5,3 +5,6 @@
 - Valentin Vinagre \<<valentin.vinagre@sygel.es>\>
 - [Quartile](https://www.quartile.co):
   - Aung Ko Ko Lin
+- [Cetmix](https://cetmix.com/)
+  - Ivan Sokolov
+  - Dmitry Meita

--- a/stock_picking_auto_create_lot/readme/USAGE.md
+++ b/stock_picking_auto_create_lot/readme/USAGE.md
@@ -1,7 +1,6 @@
 To use this module you need to:
 
-1.  Go to a *Product \> General Information tab*.
-2.  Set a tracking option for this product.
-3.  Set auto create lot.
-4.  Go to *Inventory \> Incoming* and create one.
-5.  Validate picking without lot.
+1. Create an incoming inventory operation
+2. Do not add lots or serial numbers manually
+3. Validate the operation
+4. Lots/serial numbers will be created automatically

--- a/stock_picking_auto_create_lot/static/description/index.html
+++ b/stock_picking_auto_create_lot/static/description/index.html
@@ -388,23 +388,50 @@ create lots for incoming pickings.</p>
 </div>
 <div class="section" id="configuration">
 <h1><a class="toc-backref" href="#toc-entry-1">Configuration</a></h1>
-<p>To configure this module, you need to:</p>
+<p>To use the auto-create feature you need to enable tracking by
+lots/serial numbers:</p>
 <ol class="arabic simple">
-<li>Go to a <em>Inventory &gt; Configuration &gt; Operation Types</em>.</li>
-<li>Set ‘auto create lot’ option for this operation type.</li>
-<li>Go to a <em>Inventory &gt; Master Data &gt; Products</em>.</li>
-<li>Set ‘auto create lot’ option for the products you need.</li>
+<li>Go to “Inventory &gt; Configuration &gt; Settings” and scroll down to the
+“Traceability” section;</li>
+<li>Enable the “Lots &amp; Serial Numbers” setting;</li>
+<li>You can select the number of trailing zeroes for the SKU-based
+lots/serial numbers in the “SKU Based Numbers Trailing” field located
+in the same section. Default value is “0”.</li>
+</ol>
+<p>Configure the operation types:</p>
+<ol class="arabic simple">
+<li>Go to “Inventory &gt; Configuration &gt; Operation Types”;</li>
+<li>Enable the “Auto Create Lot” setting located in the “Lots/Serial
+numbers” section.</li>
+</ol>
+<p>Configure the products you want to enable lot/serial number
+auto-creation:</p>
+<ol class="arabic simple">
+<li>Open the product form;</li>
+<li>Activate the “Track Inventory” setting and select either “By Unique
+Serial Number” or “By Lots” option;</li>
+<li>Select an option you would like to use for creating lots/serial
+numbers for this product in the “Auto Create Lot” field. Default
+options are:<ol class="arabic">
+<li>Odoo sequence. Will use default Odoo sequence for newly created
+lots;</li>
+<li>SKU based. Will use product reference as a base of the sequence
+and a number as a suffix joined by the “-” symbol. Eg for product
+with SKU “CHAIR-L-R” serial numbers will be “CHAIR-L-R-1”,
+“CHAIR-L-R-2” etc. Note: if a product doesn’t have an SKU default
+Odoo sequence will be used.</li>
+</ol>
+</li>
 </ol>
 </div>
 <div class="section" id="usage">
 <h1><a class="toc-backref" href="#toc-entry-2">Usage</a></h1>
 <p>To use this module you need to:</p>
 <ol class="arabic simple">
-<li>Go to a <em>Product &gt; General Information tab</em>.</li>
-<li>Set a tracking option for this product.</li>
-<li>Set auto create lot.</li>
-<li>Go to <em>Inventory &gt; Incoming</em> and create one.</li>
-<li>Validate picking without lot.</li>
+<li>Create an incoming inventory operation</li>
+<li>Do not add lots or serial numbers manually</li>
+<li>Validate the operation</li>
+<li>Lots/serial numbers will be created automatically</li>
 </ol>
 </div>
 <div class="section" id="bug-tracker">
@@ -434,6 +461,11 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Valentin Vinagre &lt;<a class="reference external" href="mailto:valentin.vinagre&#64;sygel.es">valentin.vinagre&#64;sygel.es</a>&gt;</li>
 <li><a class="reference external" href="https://www.quartile.co">Quartile</a>:<ul>
 <li>Aung Ko Ko Lin</li>
+</ul>
+</li>
+<li><a class="reference external" href="https://cetmix.com/">Cetmix</a><ul>
+<li>Ivan Sokolov</li>
+<li>Dmitry Meita</li>
 </ul>
 </li>
 </ul>

--- a/stock_picking_auto_create_lot/tests/common.py
+++ b/stock_picking_auto_create_lot/tests/common.py
@@ -22,17 +22,17 @@ class CommonStockPickingAutoCreateLot:
         cls.supplier = cls.env["res.partner"].create({"name": "Supplier - test"})
 
     @classmethod
-    def _create_product(cls, tracking="lot", auto=True):
-        name = f"{tracking} - {auto}"
-        return cls.env["product.product"].create(
-            {
-                "name": name,
-                "type": "consu",
-                "tracking": tracking,
-                "auto_create_lot": auto,
-                "is_storable": True,
-            }
-        )
+    def _create_product(cls, tracking="lot", option=False, sku=None):
+        vals = {
+            "name": f"{tracking} - {option}",
+            "type": "consu",
+            "tracking": tracking,
+            "is_storable": True,
+            "auto_create_lot_option": option,
+        }
+        if sku:
+            vals["default_code"] = sku
+        return cls.env["product.product"].create(vals)
 
     @classmethod
     def _create_picking(cls):

--- a/stock_picking_auto_create_lot/tests/test_stock_picking_auto_create_lot.py
+++ b/stock_picking_auto_create_lot/tests/test_stock_picking_auto_create_lot.py
@@ -1,20 +1,26 @@
 # Copyright 2018 Tecnativa - Sergio Teruel
 # Copyright 2020 ACSONE SA/NV
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from odoo.exceptions import UserError
-from odoo.tests import TransactionCase
+from odoo.exceptions import UserError, ValidationError
+from odoo.tests import TransactionCase, tagged
 
+from ..models.res_config_settings import CONFIG_PARAM_SKU_TRAILING
 from .common import CommonStockPickingAutoCreateLot
 
 
+@tagged("test1")
 class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         # Create 3 products with lot/serial and auto_create True/False
-        cls.product = cls._create_product()
-        cls.product_serial = cls._create_product(tracking="serial")
-        cls.product_serial_not_auto = cls._create_product(tracking="serial", auto=False)
+        cls.product = cls._create_product(option="odoo_sequence")
+        cls.product_serial = cls._create_product(
+            tracking="serial", option="odoo_sequence"
+        )
+        cls.product_serial_not_auto = cls._create_product(
+            tracking="serial", option=False
+        )
         cls.picking_type_in.auto_create_lot = True
 
         cls._create_picking()
@@ -106,7 +112,8 @@ class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, Transaction
         # Check if lots are unique per move and per product if managed
         # per serial
         move_lines_serial = self.picking.move_line_ids.filtered(
-            lambda m: m.product_id.tracking == "serial" and m.product_id.auto_create_lot
+            lambda m: m.product_id.tracking == "serial"
+            and m.product_id.product_tmpl_id.auto_create_lot_option
         )
         serials = []
         for move in move_lines_serial:
@@ -129,7 +136,7 @@ class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, Transaction
 
         moves = pickings.mapped("move_ids").filtered(
             lambda m: m.product_id == self.product_serial
-            and m.product_id.auto_create_lot
+            and m.product_id.product_tmpl_id.auto_create_lot_option
         )
         for line in moves.mapped("move_line_ids"):
             self.assertFalse(line.lot_name)
@@ -137,6 +144,113 @@ class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, Transaction
         pickings._action_done()
         for line in moves.mapped("move_line_ids"):
             self.assertTrue(line.lot_name)
+
+    def test_sku_based_generates_incremental_serials(self):
+        product = self._create_product(
+            tracking="serial", option="sku_based", sku="FURN_8888"
+        )
+        self._create_picking()
+        self._create_move(product=product, qty=2.0)
+        self.picking_type_in.auto_create_lot = True
+
+        self.picking.action_assign()
+
+        # Ensure 2 move lines exist for serial tracking
+        smls = self.picking.move_line_ids.filtered(
+            lambda line: line.product_id == product
+        )
+        self.assertEqual(len(smls), 2)
+
+        self.picking.button_validate()
+
+        lots = self.env["stock.lot"].search([("product_id", "=", product.id)])
+        names = sorted(lots.mapped("name"))
+        self.assertEqual(names, ["FURN_8888-1", "FURN_8888-2"])
+
+    def test_sku_based_multi_picking_validate_unique(self):
+        product = self._create_product(
+            tracking="serial", option="sku_based", sku="FURN_7777"
+        )
+        self.picking_type_in.auto_create_lot = True
+
+        self._create_picking()
+        picking_1 = self.picking
+        self._create_move(product=product, qty=1.0)
+        picking_1.action_assign()
+
+        self._create_picking()
+        picking_2 = self.picking
+        self._create_move(product=product, qty=1.0)
+        picking_2.action_assign()
+
+        pickings = picking_1 | picking_2
+        pickings.button_validate()
+
+        lots = self.env["stock.lot"].search([("product_id", "=", product.id)])
+        self.assertEqual(len(lots), 2)
+        self.assertUniqueIn(lots.mapped("name"))
+
+    def test_sku_based_without_sku_falls_back_to_odoo_sequence(self):
+        product = self._create_product(tracking="serial", option="sku_based", sku=None)
+        self.picking_type_in.auto_create_lot = True
+
+        self._create_picking()
+        self._create_move(product=product, qty=1.0)
+        self.picking.action_assign()
+
+        self.picking.button_validate()
+
+        lot = self.env["stock.lot"].search([("product_id", "=", product.id)], limit=1)
+        self.assertTrue(lot)
+        # We can't assert exact sequence format, but must be non-empty and not like "-1"
+        self.assertTrue(lot.name)
+        self.assertFalse(lot.name.startswith("-"))
+
+    def test_sku_based_respects_global_lots_company_null(self):
+        product = self._create_product(
+            tracking="serial", option="sku_based", sku="FURN_9999"
+        )
+        self.picking_type_in.auto_create_lot = True
+
+        # Create global lot (company_id is False)
+        global_lot = self.env["stock.lot"].create(
+            {
+                "name": "FURN_9999-1",
+                "product_id": product.id,
+                "company_id": False,
+            }
+        )
+
+        self._create_picking()
+        self._create_move(product=product, qty=1.0)
+        self.picking.action_assign()
+        self.picking.button_validate()
+
+        sml = self.picking.move_line_ids.filtered(
+            lambda line: line.product_id == product
+        )
+        self.assertEqual(len(sml), 1)
+        self.assertEqual(sml.lot_id, global_lot)
+
+        lots = self.env["stock.lot"].search([("product_id", "=", product.id)])
+        self.assertEqual(len(lots), 1)
+        self.assertEqual(lots, global_lot)
+
+    def test_sku_based_trailing_zeroes(self):
+        self.env["ir.config_parameter"].sudo().set_param(CONFIG_PARAM_SKU_TRAILING, "3")
+        product = self._create_product(
+            tracking="serial", option="sku_based", sku="FURN_1234"
+        )
+
+        self.picking_type_in.auto_create_lot = True
+        self._create_picking()
+        self._create_move(product=product, qty=2.0)
+        self.picking.action_assign()
+        self.picking.button_validate()
+
+        lots = self.env["stock.lot"].search([("product_id", "=", product.id)])
+        self.assertIn("FURN_1234-001", lots.mapped("name"))
+        self.assertIn("FURN_1234-002", lots.mapped("name"))
 
     def test_immediate_validate_tracked_move_with_auto_create_lot(self):
         # Clear existing move if not the picking will open backorder wizard because
@@ -164,6 +278,115 @@ class TestStockPickingAutoCreateLot(CommonStockPickingAutoCreateLot, Transaction
         self.picking.button_validate()
         lots = self.picking.move_line_ids.lot_id
         self.assertEqual(len(lots), 2)
+
+    def test_sku_based_missing_sequence_falls_back_to_odoo_sequence(self):
+        """If per-product sequence is missing, it must fallback to stock.lot.serial."""
+        product = self._create_product(
+            tracking="serial", option="sku_based", sku="FURN_MISS"
+        )
+
+        seq = product.auto_create_lot_sequence_id
+        self.assertTrue(seq)
+
+        # Make sequence missing without triggering sync hooks.
+        seq.sudo().unlink()
+        product.write({"auto_create_lot_sequence_id": False})
+        self.assertFalse(product.auto_create_lot_sequence_id)
+
+        self._create_picking()
+        self._create_move(product=product, qty=1.0)
+        self.picking.action_assign()
+
+        sml = self.picking.move_line_ids.filtered(
+            lambda line: line.product_id == product
+        )[:1]
+        self.assertTrue(sml)
+
+        name = sml._get_lot_sequence()
+        self.assertTrue(name)
+        self.assertFalse(name.startswith("FURN_MISS-"))
+
+    def test_trailing_invalid_or_negative_config_defaults_to_zero(self):
+        """Invalid/negative trailing in config param must result in padding=0."""
+        product = self._create_product(
+            tracking="serial", option="sku_based", sku="FURN_TRL"
+        )
+        product.auto_create_lot_sequence_id.write({"padding": 7})
+        product.write({"auto_create_lot_sequence_id": False})
+
+        # ValueError branch
+        self.env["ir.config_parameter"].sudo().set_param(
+            CONFIG_PARAM_SKU_TRAILING, "abc"
+        )
+        product._auto_lot_sequence_sync_if_needed()
+        self.assertEqual(product.auto_create_lot_sequence_id.padding, 0)
+
+        # max(trailing, 0) branch
+        product.write({"auto_create_lot_sequence_id": False})
+        self.env["ir.config_parameter"].sudo().set_param(
+            CONFIG_PARAM_SKU_TRAILING, "-5"
+        )
+        product._auto_lot_sequence_sync_if_needed()
+        self.assertEqual(product.auto_create_lot_sequence_id.padding, 0)
+
+    def test_product_write_syncs_sequence_on_sku_or_company_change(self):
+        """Changing SKU/company must sync per-product
+        sequence (prefix/padding/company)."""
+        self.env["ir.config_parameter"].sudo().set_param(CONFIG_PARAM_SKU_TRAILING, "2")
+
+        product = self._create_product(
+            tracking="serial", option="sku_based", sku="FURN_2000"
+        )
+        seq = product.auto_create_lot_sequence_id
+        self.assertTrue(seq)
+
+        # Put sequence out-of-sync so vals-diff/write path is executed.
+        seq.write({"prefix": "BAD-", "padding": 0, "company_id": False})
+
+        company2 = self.env["res.company"].create({"name": "Company 2"})
+        product = product.with_context(
+            allowed_company_ids=[self.env.company.id, company2.id]
+        )
+
+        # Covers: product.product.write hook and sync updates
+        product.write({"default_code": "FURN_2001", "company_id": company2.id})
+
+        seq = product.auto_create_lot_sequence_id
+        self.assertEqual(seq.prefix, "FURN_2001-")
+        self.assertEqual(seq.padding, 2)
+        self.assertEqual(seq.company_id, company2)
+
+    def test_product_unlink_deletes_dedicated_sequence(self):
+        """Deleting product must delete its dedicated sequence."""
+        product = self._create_product(
+            tracking="serial", option="sku_based", sku="FURN_DEL"
+        )
+        seq = product.auto_create_lot_sequence_id
+        self.assertTrue(seq)
+
+        seq_id = seq.id
+        product.unlink()
+
+        self.assertFalse(self.env["ir.sequence"].browse(seq_id).exists())
+
+    def test_template_write_triggers_sequence_creation_on_option_change(self):
+        """Changing template option to sku_based must create sequence for variants."""
+        product = self._create_product(
+            tracking="serial", option="odoo_sequence", sku="FURN_TPL"
+        )
+        self.assertFalse(product.auto_create_lot_sequence_id)
+
+        product.product_tmpl_id.write({"auto_create_lot_option": "sku_based"})
+
+        self.assertTrue(product.auto_create_lot_sequence_id)
+        self.assertTrue(
+            product.auto_create_lot_sequence_id.prefix.startswith("FURN_TPL-")
+        )
+
+    def test_settings_trailing_negative_raises_validation_error(self):
+        """res.config.settings must not accept negative trailing."""
+        with self.assertRaises(ValidationError):
+            self.env["res.config.settings"].create({"sku_based_numbers_trailing": -1})
 
     def _assign_manual_serials(self, moves):
         # Assign manual serials

--- a/stock_picking_auto_create_lot/views/product_views.xml
+++ b/stock_picking_auto_create_lot/views/product_views.xml
@@ -8,7 +8,7 @@
         <field name="inherit_id" ref="stock.view_template_property_form" />
         <field name="arch" type="xml">
             <xpath expr="//div[field[@name='tracking']]" position="after">
-                <field name="auto_create_lot" invisible="tracking == 'none'" />
+                <field name="auto_create_lot_option" invisible="tracking == 'none'" />
             </xpath>
         </field>
     </record>

--- a/stock_picking_auto_create_lot/views/res_config_settings_views.xml
+++ b/stock_picking_auto_create_lot/views/res_config_settings_views.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form_inherit_sku_trailing" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.sku.trailing</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="stock.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//block[@id='production_lot_info']/setting[@id='full_traceability']"
+                position="inside"
+            >
+                <div
+                    class="row mt-2 align-items-start"
+                    invisible="not group_stock_production_lot"
+                >
+                    <div class="col ps-0 ms-4">
+                        <label for="sku_based_numbers_trailing" class="o_form_label" />
+                        <div class="text-muted">
+                            Number of leading zeroes for SKU-based lot/serial suffix (e.g. 3 -> 001).
+                        </div>
+                    </div>
+
+                    <div class="col-auto">
+                        <field
+                            name="sku_based_numbers_trailing"
+                            class="o_input o_field_integer text-end"
+                        />
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Improves Stock Picking Auto Create Lot by adding per-product lot/serial generation options.

* Replaced the boolean with `auto_create_lot_option` (Odoo sequence / SKU based).
* Added Inventory setting “SKU Based Numbers Trailing” and applied it to SKU-based numbering.
* Implemented SKU-based lots/serials as `<SKU>-<N>` using an auto-managed per-product `ir.sequence`, with fallback to `stock.lot.serial` when SKU is missing.
* Added migration (bool -> selection), updated docs, and extended tests to keep codecov diff coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-product choice for lot/serial generation (Odoo sequence or SKU‑based), automatic lot/serial creation on validation, per-product sequences, and global SKU trailing digits setting.

* **Documentation**
  * Rewrote configuration and usage into a unified, settings-driven Traceability flow; updated contributors list.

* **Tests**
  * Added comprehensive SKU-based tests: incremental numbering, trailing zeros, fallbacks, uniqueness, multi-picking, sync and deletion behaviors.

* **Chores**
  * Module version bump and migration to align existing products with the new option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->